### PR TITLE
fixing build trigger

### DIFF
--- a/build/azDevOps/packages-amido-stacks-core.yml
+++ b/build/azDevOps/packages-amido-stacks-core.yml
@@ -51,7 +51,7 @@ variables:
 trigger:
   branches:
     include:
-    - 'main'
+      - main
   paths:
     include:
     - '*'


### PR DESCRIPTION
The build script isn't being triggered after a merge to `main`.  

This looks to fix the issue.